### PR TITLE
Don't set temp_cold_seconds

### DIFF
--- a/libfprint/libfprint/libfprint/drivers/synatlsmoc/synatlsmoc.c
+++ b/libfprint/libfprint/libfprint/drivers/synatlsmoc/synatlsmoc.c
@@ -4005,10 +4005,7 @@ fpi_device_synatlsmoc_class_init (FpiDeviceSynaTlsMocClass *klass)
   dev_class->id_table = id_table;
   dev_class->nr_enroll_stages = SYNATLSMOC_ENROLL_STAGES;
   dev_class->scan_type = FP_SCAN_TYPE_PRESS;
-
   dev_class->temp_hot_seconds = -1;
-  // FIXME: was this left out intentionally
-  dev_class->temp_cold_seconds = -1;
 
   dev_class->open = synatlsmoc_open;
   dev_class->close = synatlsmoc_close;


### PR DESCRIPTION
`temp_cold_seconds` is set to -1 by `FpDevice` logic when `temp_hot_seconds < 0`