### PR TITLE
synatlsmoc: add support for 06cb:00d8

### DIFF
--- a/libfprint/libfprint/libfprint/drivers/synatlsmoc/synatlsmoc.c
+++ b/libfprint/libfprint/libfprint/drivers/synatlsmoc/synatlsmoc.c
@@ -108,6 +108,7 @@ static const FpIdEntry id_table[] = {
     /* the sensors commented out are untested, but should be suported */
     // { .vid = SYNAPTICS_VENDOR_ID,  .pid = 0x00C9, },
     // { .vid = SYNAPTICS_VENDOR_ID,  .pid = 0x00D1, },
+    { .vid = SYNAPTICS_VENDOR_ID, .pid = 0x00D8, }, /* HP ProBook 445 G7 - Prometheus */
     { .vid = SYNAPTICS_VENDOR_ID,  .pid = 0x00E7, },
     { .vid = SYNAPTICS_VENDOR_ID, .pid = 0x00FF, },
     // { .vid = SYNAPTICS_VENDOR_ID,  .pid = 0x0124, },

--- a/libfprint/libfprint/libfprint/drivers/synatlsmoc/synatlsmoc.h
+++ b/libfprint/libfprint/libfprint/drivers/synatlsmoc/synatlsmoc.h
@@ -212,7 +212,9 @@ enum ENROLL_SUBCMDS
 
 enum CAPTURE_FLAGS
 {
-  CAPTURE_FLAG_AUTH = 7,
+  /* NOTE: Prometheus (0x00d8) requires flags=15 for matching, flags=7 returns
+   * MATCH_FAILED (0x0509). Using 15 for both auth and enroll for safety. */
+  CAPTURE_FLAG_AUTH = 15,
   CAPTURE_FLAG_ENROLL = 15,
 };
 


### PR DESCRIPTION
Add support for Synaptics 06cb:00d8 sensor (Tudor MiS family).

- Adds 0x00D8 to id_table
- Sets CAPTURE_FLAG_AUTH to 15 for this PID

Tested with synaTudorMiS driver.